### PR TITLE
Add generic workflow to publish projects

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -1,0 +1,36 @@
+name: Project release on PyPi
+
+on:
+  push:
+    tags:
+      - "^.*-v[0-9].[0-9]+.[0-9]+$"
+
+jobs:
+  release-on-pypi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      - name: Get project folder
+        id: pathfinder
+        shell: python
+        run: |
+          project_path = "${{ github.ref_name }}".rsplit("-", maxsplit=1)[0]
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            print(f'{project_path}={project_path}', file=f)
+
+      - name: Build extra
+        working-directory: ${{ steps.pathfinder.outputs.project_path }}
+        run: hatch build
+
+      - name: Publish on PyPi
+        working-directory: ${{ steps.pathfinder.outputs.project_path }}
+        env:
+          HATCH_INDEX_USER: __token__
+          HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}
+        run: hatch publish -y

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -1,5 +1,14 @@
 name: Project release on PyPi
 
+# The pushed tag must be formatted like so:
+# * nodes/speech2text-v1.0.0
+# * stores/mongodb-documentstore-v1.2.3
+#
+# The first part must be the path of the project being released.
+# If we want to release version 1.0.0 of project speech2text
+# that lives in path nodes/speech2text we'd have to push a
+# nodes/speech2text-v1.0.0 tag.
+
 on:
   push:
     tags:


### PR DESCRIPTION
Workflow will be triggered whenever a tag formatted like `<project_path>-v<project_version>` is pushed.

To publish the `text2speech` extra version `1.0.0` one would need to push a `nodes/text2speech-v1.0.0` tag.