### PR TITLE
Fix text2speech dependencies

### DIFF
--- a/nodes/text2speech/pyproject.toml
+++ b/nodes/text2speech/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "soundfile",
   "pyworld<=0.2.12",
   "espnet",
+  "typeguard==2.13.3",
   "espnet-model-zoo",
   "pydub",
   "ffmpeg-python"


### PR DESCRIPTION
Fixes failing tests for `text2speech` package.
Related failure: https://github.com/deepset-ai/haystack-extras/actions/runs/4424729918/jobs/7758905520

More info in deepset-ai/haystack#4418.