### PR TITLE
Fixed pyworld dependency version for text2speech module

### DIFF
--- a/nodes/text2speech/pyproject.toml
+++ b/nodes/text2speech/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "torch",
   "pydantic",
   "soundfile",
-  "pyworld<=0.2.12",
+  "pyworld>=0.3.1",
   "espnet",
   "typeguard==2.13.3",
   "espnet-model-zoo",


### PR DESCRIPTION
I found an issue related to a specific dependency, pyworld in the text2speech module. The project specifically requires pyworld version <= 0.2.12.

However, when attempting to install the library with the specified version using the command ```pip install pyworld<=0.2.12``` (or by default ```pip install farm-haystack-text2speech```), the installation process fails by deprecation with the following error:

```powershell
PS C:\Users\path pip install pyworld<=0.2.12
Collecting pyworld<=0.2.12
  Using cached pyworld-0.2.12.tar.gz (222 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [70 lines of output]
      C:\Users\user\AppData\Local\Temp\pip-build-env-_476vg7x\overlay\Lib\site-packages\setuptools\dist.py:745: SetuptoolsDeprecationWarning: Invalid dash-separated options
              ********************************************************************************
              Usage of dash-separated 'description-file' will not be supported in future
              versions. Please use the underscore name 'description_file' instead.

              By 2023-Sep-26, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.

              See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
              ********************************************************************************
```

I updated pyword requirement to 0.3.1 where this issue is already fixed.