### PR TITLE
Add instructor-embedders empty sub-project

### DIFF
--- a/.github/workflows/components_instructor_embedders
+++ b/.github/workflows/components_instructor_embedders
@@ -1,0 +1,38 @@
+name: Test / instructor-embedders
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - 'components/instructor-embedders/**'
+      - '.github/workflows/components_instructor_embedders.yml'
+
+defaults:
+  run:
+    working-directory: components/instructor-embedders
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install instructor-embedders
+      run: |
+        pip install -e .[dev]
+
+    - name: Pylint
+      run: |
+        pylint -ry -j 0 ./instructor_embedders
+
+    - name: Run tests
+      run: |
+        pytest

--- a/components/README.md
+++ b/components/README.md
@@ -1,0 +1,6 @@
+# Components (for Haystack 2.x)
+
+To create a new package, run this command:
+```sh
+hatch --config hatch.toml new my_custom_component
+```

--- a/components/hatch.toml
+++ b/components/hatch.toml
@@ -1,0 +1,12 @@
+[template]
+name = "deepset GmbH"
+email = "info@deepset.ai"
+
+[template.licenses]
+headers = true
+default = [
+  "Apache-2.0",
+]
+
+[template.plugins.default]
+src-layout = false

--- a/components/instructor-embedders/LICENSE.txt
+++ b/components/instructor-embedders/LICENSE.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/components/instructor-embedders/README.md
+++ b/components/instructor-embedders/README.md
@@ -1,7 +1,7 @@
 # instructor_embedders
 
-[![PyPI - Version](https://img.shields.io/pypi/v/haystack-instructor-embedders.svg)](https://pypi.org/project/haystack-instructor-embedders)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/haystack-instructor-embedders.svg)](https://pypi.org/project/haystack-instructor-embedders)
+[![PyPI - Version](https://img.shields.io/pypi/v/instructor-embedders-haystack.svg)](https://pypi.org/project/instructor-embedders-haystack)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/instructor-embedders-haystack.svg)](https://pypi.org/project/instructor-embedders-haystack)
 
 -----
 

--- a/components/instructor-embedders/README.md
+++ b/components/instructor-embedders/README.md
@@ -1,0 +1,22 @@
+# instructor_embedders
+
+[![PyPI - Version](https://img.shields.io/pypi/v/haystack-instructor-embedders.svg)](https://pypi.org/project/haystack-instructor-embedders)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/haystack-instructor-embedders.svg)](https://pypi.org/project/haystack-instructor-embedders)
+
+-----
+
+**Table of Contents**
+
+- [instructor\_embedders](#instructor_embedders)
+  - [Installation](#installation)
+  - [License](#license)
+
+## Installation
+
+```console
+pip install instructor-embedders
+```
+
+## License
+
+`instructor-embedders` is distributed under the terms of the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) license.

--- a/components/instructor-embedders/instructor_embedders/__about__.py
+++ b/components/instructor-embedders/instructor_embedders/__about__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+__version__ = "0.0.1"

--- a/components/instructor-embedders/instructor_embedders/__init__.py
+++ b/components/instructor-embedders/instructor_embedders/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/components/instructor-embedders/pyproject.toml
+++ b/components/instructor-embedders/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "haystack-instructor-embedders"
+name = "instructor-embedders-haystack"
 dynamic = ["version"]
 description = 'Haystack 2.x component to embed strings and Documents using Instructor embedding model.'
 readme = "README.md"
@@ -27,9 +27,10 @@ classifiers = [
 dependencies = [
   "haystack-ai",
 
-  # the following dependencies are copied from https://github.com/xlang-ai/instructor-embedding/blob/main/requirements.txt
-  # since the InstructorEmbedding package does not install them, but they are mandatory
-  "transformers==4.20.0",
+  # The following dependencies are copied from https://github.com/xlang-ai/instructor-embedding/blob/main/requirements.txt
+  # since the InstructorEmbedding package does not install them, but they are mandatory.
+  # Commenting some of them to not interfere with the dependencies of Haystack.
+  #"transformers==4.20.0",
   "datasets>=2.2.0",
   "pyarrow==8.0.0",
   "jsonlines",

--- a/components/instructor-embedders/pyproject.toml
+++ b/components/instructor-embedders/pyproject.toml
@@ -1,0 +1,176 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "haystack-instructor-embedders"
+dynamic = ["version"]
+description = 'Haystack 2.x component to embed strings and Documents using Instructor embedding model.'
+readme = "README.md"
+requires-python = ">=3.7"
+license = "Apache-2.0"
+keywords = []
+authors = [
+  { name = "deepset GmbH", email = "info@deepset.ai" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = [
+  "haystack-ai",
+
+  # the following dependencies are copied from https://github.com/xlang-ai/instructor-embedding/blob/main/requirements.txt
+  # since the InstructorEmbedding package does not install them, but they are mandatory
+  "transformers==4.20.0",
+  "datasets>=2.2.0",
+  "pyarrow==8.0.0",
+  "jsonlines",
+  "numpy",
+  "requests>=2.26.0",
+  "scikit_learn>=1.0.2",
+  "scipy",
+  "sentence_transformers>=2.2.0",
+  "torch",
+  "tqdm",
+  "rich",
+
+  "InstructorEmbedding"
+]
+
+[project.urls]
+Documentation = "https://github.com/deepset-ai/haystack-extras/tree/main/components/instructor-embedders#readme"
+Issues = "https://github.com/deepset-ai/haystack-extras/issues"
+Source = "https://github.com/deepset-ai/haystack-extras/tree/main/components/text2speech"
+
+[tool.hatch.version]
+path = "instructor_embedders/__about__.py"
+
+[tool.hatch.envs.default]
+dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest",
+]
+[tool.hatch.envs.default.scripts]
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+cov-report = [
+  "- coverage combine",
+  "coverage report",
+]
+cov = [
+  "test-cov",
+  "cov-report",
+]
+
+[[tool.hatch.envs.all.matrix]]
+python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+[tool.hatch.envs.lint]
+detached = true
+dependencies = [
+  "black>=23.1.0",
+  "mypy>=1.0.0",
+  "ruff>=0.0.243",
+]
+[tool.hatch.envs.lint.scripts]
+typing = "mypy --install-types --non-interactive {args:instructor_embedders tests}"
+style = [
+  "ruff {args:.}",
+  "black --check --diff {args:.}",
+]
+fmt = [
+  "black {args:.}",
+  "ruff --fix {args:.}",
+  "style",
+]
+all = [
+  "style",
+  "typing",
+]
+
+[tool.black]
+target-version = ["py37"]
+line-length = 120
+skip-string-normalization = true
+
+[tool.ruff]
+target-version = "py37"
+line-length = 120
+select = [
+  "A",
+  "ARG",
+  "B",
+  "C",
+  "DTZ",
+  "E",
+  "EM",
+  "F",
+  "FBT",
+  "I",
+  "ICN",
+  "ISC",
+  "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "Q",
+  "RUF",
+  "S",
+  "T",
+  "TID",
+  "UP",
+  "W",
+  "YTT",
+]
+ignore = [
+  # Allow non-abstract empty methods in abstract base classes
+  "B027",
+  # Allow boolean positional values in function calls, like `dict.get(... True)`
+  "FBT003",
+  # Ignore checks for possible passwords
+  "S105", "S106", "S107",
+  # Ignore complexity
+  "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
+]
+unfixable = [
+  # Don't touch unused imports
+  "F401",
+]
+
+[tool.ruff.isort]
+known-first-party = ["instructor_embedders"]
+
+[tool.ruff.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[tool.ruff.per-file-ignores]
+# Tests can use magic values, assertions, and relative imports
+"tests/**/*" = ["PLR2004", "S101", "TID252"]
+
+[tool.coverage.run]
+source_pkgs = ["instructor_embedders", "tests"]
+branch = true
+parallel = true
+omit = [
+  "instructor_embedders/__about__.py",
+]
+
+[tool.coverage.paths]
+instructor_embedders = ["instructor_embedders", "*/instructor-embedders/instructor_embedders"]
+tests = ["tests", "*/instructor-embedders/tests"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]

--- a/components/instructor-embedders/tests/__init__.py
+++ b/components/instructor-embedders/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
As discussed offline, for dependency reasons,
we would like to include the Instructor Embedders (for Haystack 2.x) in a sub-project of haystack-extras.

I set up and created the bare minimum to help the contributor move his PR to this repository.